### PR TITLE
Multiple connections

### DIFF
--- a/src/RedisReact/RedisReact.ServiceInterface/Extensions.cs
+++ b/src/RedisReact/RedisReact.ServiceInterface/Extensions.cs
@@ -1,0 +1,44 @@
+﻿using RedisReact.ServiceModel;
+using ServiceStack;
+using ServiceStack.Redis;
+
+namespace RedisReact.ServiceInterface
+{
+    public static class Extensions
+    {
+        public static string GetKey(this ConnectionRequest request)
+        {
+            return "redis-connection-{0}:{1}".Fmt(request.Host, request.Port);
+        }
+
+        public static ConnectionRequest WithDefaults(this ConnectionRequest request)
+        {
+            return new ConnectionRequest {
+                Host = request.Host ?? "127.0.0.1",
+                Port = request.Port.GetValueOrDefault(6379),
+                Db = request.Db.GetValueOrDefault(0),
+                IsActive = request.IsActive,
+                Password = request.Password
+            };
+        }
+
+        public static string ToConnectionString(this ConnectionRequest request)
+        {
+            var connString = "{0}:{1}?db={2}".Fmt(
+                request.Host,
+                request.Port,
+                request.Db);
+
+            if (!string.IsNullOrEmpty(request.Password))
+                connString += "&password=" + request.Password.UrlEncode();
+
+            return connString;
+        }
+
+        public static bool IsEquvalentTo(this IRedisClient redis, ConnectionRequest request)
+        {
+            return request.Host == redis.Host && request.Port == redis.Port;
+        }
+
+    }
+}

--- a/src/RedisReact/RedisReact.ServiceInterface/RedisReact.ServiceInterface.csproj
+++ b/src/RedisReact/RedisReact.ServiceInterface/RedisReact.ServiceInterface.csproj
@@ -71,6 +71,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Extensions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="RedisServices.cs" />
     <Compile Include="SharedUtils.cs" />

--- a/src/RedisReact/RedisReact.ServiceInterface/RedisServices.cs
+++ b/src/RedisReact/RedisReact.ServiceInterface/RedisServices.cs
@@ -97,8 +97,14 @@ return cjson.encode(keyAttrs)";
             if (!string.IsNullOrEmpty(request.Password))
                 connString += "&password=" + request.Password.UrlEncode();
 
-            var testConnection = new RedisClient(connString);
-            testConnection.Ping();
+            try {
+                var testConnection = new RedisClient(connString);
+                testConnection.Ping();
+            } catch {
+                connString += "&ssl=true";
+                var testConnection = new RedisClient(connString);
+                testConnection.Ping();
+            }
 
             ((IRedisFailover)TryResolve<IRedisClientsManager>()).FailoverTo(connString);
 

--- a/src/RedisReact/RedisReact.ServiceModel/CallRedis.cs
+++ b/src/RedisReact/RedisReact.ServiceModel/CallRedis.cs
@@ -4,25 +4,42 @@ using ServiceStack.Redis;
 
 namespace RedisReact.ServiceModel
 {
-    [Route("/connection", "GET")]
-    public class GetConnection : IReturn<GetConnectionResponse> { }
+    [Route("/connections", "GET")]
+    public class GetConnections : IReturn<GetConnectionsResponse> { }
 
-    public class GetConnectionResponse
+    public class GetConnectionsResponse
+    {
+        public List<Connection> Connections { get; set; }
+
+        public ResponseStatus ResponseStatus { get; set; }
+    }
+
+    public class Connection
     {
         public string Host { get; set; }
         public int Port { get; set; }
         public int Db { get; set; }
 
-        public ResponseStatus ResponseStatus { get; set; }
+        public bool IsActive { get; set; }
+        public bool? IsMaster { get; set; }
     }
 
-    [Route("/connection", "POST")]
-    public class ChangeConnection : IReturn<GetConnectionResponse>
+    [Route("/connections", "POST")]
+    public class ConnectionRequest : IReturn<GetConnectionsResponse>
     {
         public string Host { get; set; }
         public int? Port { get; set; }
         public int? Db { get; set; }
+
         public string Password { get; set; }
+        public bool? IsActive { get; set; }
+    }
+
+    [Route("/connections/{host}", "DELETE")]
+    public class DeleteConnection : IReturn<GetConnectionsResponse>
+    {
+        public string Host { get; set; }
+        public int? Port { get; set; }
     }
 
     [Route("/call-redis")]

--- a/src/RedisReact/RedisReact/css/app.css
+++ b/src/RedisReact/RedisReact/css/app.css
@@ -42,27 +42,30 @@ h1 {
 #connections-page {
     text-align: center;
 }
-#formConnection {
+.form-inline {
     padding: 40px 0 0 0;
     margin: 0 auto;
 }
-#formConnection h2 {
+.form-inline h2 {
     margin: 0 0 40px 0;
 }
-#formConnection  input {
+.form-inline input {
     margin: 0 10px;
 }
-#formConnection #txtHost {
+.form-inline #txtHost {
     width: 200px;
 }
-#formConnection #txtPort {
+.form-inline #txtPort {
     width: 70px;
 }
-#formConnection #txtDb {
+.form-inline #txtDb {
     width: 40px;
 }
-#formConnection .actions {
+.form-inline .actions {
     margin: 20px 0;
+}
+.form-inline #btnDelete {
+    margin: 0 10px;
 }
 .loader {
     visibility: hidden;
@@ -155,6 +158,10 @@ body.search-active, body.search-active .navbar {
     text-align: center;
     margin: 70px 0 0 0;
 }
+#connections-page .content {
+    text-align: left;
+}
+
 #formSearch {
     background: #f5f5f5;
     border-radius: 2px;

--- a/src/RedisReact/RedisReact/css/app.css
+++ b/src/RedisReact/RedisReact/css/app.css
@@ -64,7 +64,10 @@ h1 {
 .form-inline .actions {
     margin: 20px 0;
 }
-.form-inline #btnDelete {
+td .btn-default {
+    margin: 0 10px 0 0;
+}
+.form-inline #btnCancel {
     margin: 0 10px;
 }
 .loader {

--- a/src/RedisReact/RedisReact/js/app.jsx
+++ b/src/RedisReact/RedisReact/js/app.jsx
@@ -34,7 +34,7 @@
         var Connection = <b>not connected</b>;
         var conn = this.state.connection;
         if (conn != null) {
-            Connection = <b>{conn.host}:{conn.port} db={conn.db}</b>;
+            Connection = <b>{conn.host}:{conn.port} db={conn.db} {!conn.isMaster ? 'slave' : 'master'}</b>;
         }
 
         var ClearSearch = null;
@@ -117,4 +117,4 @@ Router.run(routes, function (Handler, state) {
 
 
 Actions.viewInfo();
-Actions.loadConnection();
+Actions.loadConnections();

--- a/src/RedisReact/RedisReact/js/components/connections.jsx
+++ b/src/RedisReact/RedisReact/js/components/connections.jsx
@@ -3,13 +3,10 @@
         Reflux.listenTo(ConnectionStore, "onConnection")
     ],
     getInitialState: function () {
-        return { connection: ConnectionStore.connection, successMessage: null };
+        return { connections: ConnectionStore.connections, connection: null, successMessage: null };
     },
-    componentDidMount: function () {
-        this.refs.txtHost.getDOMNode().focus();
-    },
-    onConnection: function (connection) {
-        this.setState({ connection: connection });
+    onConnection: function () {
+        this.setState({ connections: ConnectionStore.connections });
     },
     selectText: function (e) {
         var target = e.target;
@@ -18,12 +15,15 @@
         }, 0);
     },
     onChange: function (e) {
-        var conn = this.state.connection || {};
+        var oldIndex = this.state.index || 0;
+        var index = e.target.parentElement.id.split('_')[1];
+        var conn = (index != oldIndex) ? {} : this.state.connection || {};
         conn[e.target.name] = e.target.value;
-        this.setState({ connection: conn });
+        this.setState({ connection: conn, index: index });
     },
     onSubmit: function (e) {
         e.preventDefault();
+        var index = e.target.parentElement.id.split('_')[1];
 
         this.setState({ successMessage: null });
 
@@ -31,48 +31,83 @@
         $(e.target).ajaxSubmit({
             onSubmitDisable: $("#btnConnect"),
             success: function () {
-                $this.setState({ successMessage: "Connection was changed" });
-                Actions.loadConnection();
+                $this.setState({ successMessage: index === 0 ? "Connection was added" : "Connection was updated" });
+                Actions.loadConnections();
             }
         });
     },
+    //onAdd: function (e) {
+    //    e.preventDefault();
+    //    this.setState({ successMessage: null });
+
+    //    var $this = this;
+    //    $(e.target).ajaxSubmit({
+    //        onSubmitDisable: $("#btnConnect"),
+    //        success: function () {
+    //            $this.setState({ successMessage: "Connection was added" });
+    //            Actions.loadConnections();
+    //        }
+    //    });
+
+    //},
+    renderConnection: function(i) {
+        var $this = this;
+        var connection = this.state.connections[i] || this.state.connection;
+
+        var color = "#000";
+        var Buttons = [];
+        if (!this.state.connections[i]) {
+            Buttons.push(<button id="btnConnect" className="btn btn-default btn-primary">Add</button>);
+        } else {
+            if (!connection.isActive) {
+                Buttons.push(<button id="btnConnect" className="btn btn-default btn-primary">Update & Connect</button>);
+            } else {
+                color = "#2cbe4e";
+                Buttons.push(<button id="btnConnect" className="btn btn-default btn-primary">Update</button>);
+            }
+            Buttons.push(<button id="btnDelete" className="btn btn-default btn-danger" onClick={$this.onDelete}>X</button>);
+        }
+
+        let groupId = "connection_" + i;
+        return (
+            <form id="formConnection" className="form-inline" onSubmit={this.onSubmit} action="/connections">
+                <div className="form-group" id={groupId}>
+                    <label className="octicon octicon-radio-tower" style={{color: color}}></label>
+                    <input id="txtHost" name="host" type="text" className="form-control" placeholder="127.0.0.1" spellCheck="false" onChange={$this.onChange} onFocus={$this.selectText} value={connection ? connection.host : ""} />
+                    <label>:</label>
+                    <input id="txtPort" name="port" type="text" className="form-control" placeholder="6379" spellCheck="false" onChange={$this.onChange} onFocus={$this.selectText} value={connection ? connection.port : ""} />
+                    <label>auth</label>
+                    <input id="txtPassword" name="password" type="password" className="form-control" placeholder="password" spellCheck="false" onChange={this.onChange} onFocus={this.selectText} value={connection ? connection.password : ""} />
+                    <label>db</label>
+                    <input id="txtDb" name="db" type="text" className="form-control" placeholder="0" spellCheck="false" onChange={$this.onChange} onFocus={this.selectText} value={connection ? connection.db : ""} />
+                    {Buttons}
+                </div>
+            </form>
+        );
+    },
     render: function () {
-        var conn = this.state.connection;
+        var Connections = [];
+        if (this.state.connections != null && this.state.connections.length > 0) {
+            for (let i = 0; i < this.state.connections.length; i++) {
+                Connections.push(this.renderConnection(i));
+            }
+        }
+        Connections.push(this.renderConnection(Connections.length)); // the connection that hasn't been added to the server yet
+
+        //<form id="formConnection" className="form-inline" onSubmit={this.onSubmit} action="/connections">
+        //    <p className="actions">
+        //        <img className="loader" src="/img/ajax-loader.gif" />
+        //        <button id="btnConnect" className="btn btn-default btn-primary">Update Connections</button>
+        //    </p>
+        //</form>
+
         return (
           <div id="connections-page">
             <div className="content">
-                <form id="formConnection" className="form-inline" onSubmit={this.onSubmit}
-                      action="/connection">
-                    <h2>Redis Connection</h2>
-                    <div className="form-group">
-                        <label className="octicon octicon-radio-tower"></label>
-                        <input ref="txtHost" id="txtHost" name="host" type="text" className="form-control" placeholder="127.0.0.1" spellCheck="false"
-                               onChange={this.onChange} onFocus={this.selectText}
-                               value={conn ? conn.host : ""}
-                               />
-                        <label>:</label>
-                        <input id="txtPort" name="port" type="text" className="form-control" placeholder="6379" spellCheck="false"
-                               onChange={this.onChange} onFocus={this.selectText}
-                               value={conn ? conn.port : ""}
-                               />
-                        <label>db</label>
-                        <input id="txtDb" name="db" type="text" className="form-control" placeholder="0" spellCheck="false"
-                               onChange={this.onChange} onFocus={this.selectText}
-                               value={conn ? conn.db : ""}
-                               />
-                        <label>auth</label>
-                        <input id="txtPassword" name="password" type="password" className="form-control" placeholder="password" spellCheck="false"
-                               onChange={this.onChange} onFocus={this.selectText}
-                               value={conn ? conn.password : ""}
-                               />
-                    </div>
-                    <p className="actions">
-                        <img className="loader" src="/img/ajax-loader.gif" />
-                        <button id="btnConnect" className="btn btn-default btn-primary">Change Connection</button>
-                    </p>
-                    <p className="bg-success">{this.state.successMessage}</p>
-                    <p className="bg-danger error-summary"></p>
-                </form>
+                <h2>Redis Connections</h2>
+                {Connections}
+                <p className="bg-success">{this.state.successMessage}</p>
+                <p className="bg-danger error-summary"></p>
             </div>
           </div>
         );

--- a/src/RedisReact/RedisReact/js/components/connections.jsx
+++ b/src/RedisReact/RedisReact/js/components/connections.jsx
@@ -14,100 +14,138 @@
             target.select();
         }, 0);
     },
-    onChange: function (e) {
-        var oldIndex = this.state.index || 0;
-        var index = e.target.parentElement.id.split('_')[1];
-        var conn = (index != oldIndex) ? {} : this.state.connection || {};
+    onChange: function(e) {
+        var conn = this.state.connection || {};
         conn[e.target.name] = e.target.value;
-        this.setState({ connection: conn, index: index });
+        this.setState({ connection: conn });
     },
-    onSubmit: function (e) {
+    onClear: function(e) {
         e.preventDefault();
-        var index = e.target.parentElement.id.split('_')[1];
+        this.setState({ connection: null });
+    },
+    onSubmit: function(e) {
+        e.preventDefault();
 
         this.setState({ successMessage: null });
 
         var $this = this;
         $(e.target).ajaxSubmit({
-            onSubmitDisable: $("#btnConnect"),
-            success: function () {
-                $this.setState({ successMessage: index === 0 ? "Connection was added" : "Connection was updated" });
+            onSubmitDisable: $("#btnSave"),
+            success: function() {
+                $this.setState({ successMessage: "Connections updated" });
                 Actions.loadConnections();
             }
         });
     },
-    //onAdd: function (e) {
-    //    e.preventDefault();
-    //    this.setState({ successMessage: null });
+    onDelete: function(e, conn) {
+        e.preventDefault();
 
-    //    var $this = this;
-    //    $(e.target).ajaxSubmit({
-    //        onSubmitDisable: $("#btnConnect"),
-    //        success: function () {
-    //            $this.setState({ successMessage: "Connection was added" });
-    //            Actions.loadConnections();
-    //        }
-    //    });
-
-    //},
-    renderConnection: function(i) {
         var $this = this;
-        var connection = this.state.connections[i] || this.state.connection;
+        Redis.deleteConnection(conn)
+            .then(function (r) {
+                $this.setState({ successMessage: "Deleted " + conn.host + ":" + conn.port, connections: r.connections });
+            });
+    },
+    onConnect: function (e, conn) {
+        e.preventDefault();
 
-        var color = "#000";
-        var Buttons = [];
-        if (!this.state.connections[i]) {
-            Buttons.push(<button id="btnConnect" className="btn btn-default btn-primary">Add</button>);
-        } else {
-            if (!connection.isActive) {
-                Buttons.push(<button id="btnConnect" className="btn btn-default btn-primary">Update & Connect</button>);
-            } else {
-                color = "#2cbe4e";
-                Buttons.push(<button id="btnConnect" className="btn btn-default btn-primary">Update</button>);
-            }
-            Buttons.push(<button id="btnDelete" className="btn btn-default btn-danger" onClick={$this.onDelete}>X</button>);
-        }
-
-        let groupId = "connection_" + i;
-        return (
-            <form id="formConnection" className="form-inline" onSubmit={this.onSubmit} action="/connections">
-                <div className="form-group" id={groupId}>
-                    <label className="octicon octicon-radio-tower" style={{color: color}}></label>
-                    <input id="txtHost" name="host" type="text" className="form-control" placeholder="127.0.0.1" spellCheck="false" onChange={$this.onChange} onFocus={$this.selectText} value={connection ? connection.host : ""} />
-                    <label>:</label>
-                    <input id="txtPort" name="port" type="text" className="form-control" placeholder="6379" spellCheck="false" onChange={$this.onChange} onFocus={$this.selectText} value={connection ? connection.port : ""} />
-                    <label>auth</label>
-                    <input id="txtPassword" name="password" type="password" className="form-control" placeholder="password" spellCheck="false" onChange={this.onChange} onFocus={this.selectText} value={connection ? connection.password : ""} />
-                    <label>db</label>
-                    <input id="txtDb" name="db" type="text" className="form-control" placeholder="0" spellCheck="false" onChange={$this.onChange} onFocus={this.selectText} value={connection ? connection.db : ""} />
-                    {Buttons}
-                </div>
-            </form>
-        );
+        var $this = this;
+        Redis.setConnection(conn)
+            .then(function (r) {
+                $this.setState({ successMessage: "Connected to " + conn.host + ":" + conn.port, connections: r.connections });
+            });
+    },
+    onUpdate: function (e, conn) {
+        e.preventDefault();
+        this.setState({ connection: conn });
     },
     render: function () {
-        var Connections = [];
-        if (this.state.connections != null && this.state.connections.length > 0) {
-            for (let i = 0; i < this.state.connections.length; i++) {
-                Connections.push(this.renderConnection(i));
-            }
-        }
-        Connections.push(this.renderConnection(Connections.length)); // the connection that hasn't been added to the server yet
+        const conn = this.state.connection;
+        var $this = this;
 
-        //<form id="formConnection" className="form-inline" onSubmit={this.onSubmit} action="/connections">
-        //    <p className="actions">
-        //        <img className="loader" src="/img/ajax-loader.gif" />
-        //        <button id="btnConnect" className="btn btn-default btn-primary">Update Connections</button>
-        //    </p>
-        //</form>
+        var ExistingConnections = {};
+        if (this.state.connections !== null) {
+            ExistingConnections = (
+                    <table className="table table-striped wrap">
+                        <thead>
+                            <tr>
+                                <td></td>
+                                <td>Host</td>
+                                <td>Port</td>
+                                <td>Db</td>
+                                <td>Role</td>
+                                <td>Actions</td>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {this.state.connections.map(function (conn) {
+                                var Status = null;
+                                var Buttons = [];
+                                const onUpdate = (e) => {
+                                    $this.onUpdate(e, conn);
+                                };
+                                Buttons.push(<button className="btn btn-default btn-primary" onClick={onUpdate}>Update</button>);
+                                if (!conn.isActive) {
+                                    Status = <label className="octicon octicon-radio-tower"></label>;
+                                    const onConnect = (e) => {
+                                        $this.onConnect(e, conn);
+                                    };
+                                    Buttons.push(<button className="btn btn-default btn-success octicon octicon-radio-tower" onClick={onConnect}></button>);
+                                    const onDelete = (e) => {
+                                        $this.onDelete(e, conn);
+                                    };
+                                    Buttons.push(<button className="btn btn-default btn-danger octicon octicon-x" onClick={onDelete}></button>);
+                                } else {
+                                    Status = <label className="octicon octicon-radio-tower" style={{ color: "#2cbe4e" }}></label>;
+                                }
+                                return (
+                                    <tr key={conn.host + ":" + conn.port}>
+                                        <td>{Status}</td>
+                                        <td>{conn.host}</td>
+                                        <td>{conn.port}</td>
+                                        <td>{conn.db}</td>
+                                        <td>{conn.isMaster ? "master" : ""}</td>
+                                        <td>{Buttons}</td>
+                                    </tr>
+                                    );
+                                })}
+                        </tbody>
+                </table>
+            );
+        }
 
         return (
           <div id="connections-page">
             <div className="content">
                 <h2>Redis Connections</h2>
-                {Connections}
-                <p className="bg-success">{this.state.successMessage}</p>
-                <p className="bg-danger error-summary"></p>
+                {ExistingConnections}
+                <form id="formConnection" className="form-inline" onSubmit={this.onSubmit} action="/connections">
+                    <div className="form-group">
+                        <label className="octicon octicon-radio-tower"></label>
+                        <input ref="txtHost" id="txtHost" name="host" type="text" className="form-control" placeholder="127.0.0.1" spellCheck="false"
+                               onChange={this.onChange} onFocus={this.selectText}
+                               value={conn ? conn.host : ""} />
+                        <label>:</label>
+                        <input id="txtPort" name="port" type="text" className="form-control" placeholder="6379" spellCheck="false"
+                               onChange={this.onChange} onFocus={this.selectText}
+                               value={conn ? conn.port : ""} />
+                        <label>db</label>
+                        <input id="txtDb" name="db" type="text" className="form-control" placeholder="0" spellCheck="false"
+                               onChange={this.onChange} onFocus={this.selectText}
+                               value={conn ? conn.db : ""} />
+                        <label>auth</label>
+                        <input id="txtPassword" name="password" type="password" className="form-control" placeholder="password" spellCheck="false"
+                               onChange={this.onChange} onFocus={this.selectText}
+                               value={conn ? conn.password : ""} />
+                    </div>
+                    <p className="actions">
+                        <img className="loader" src="/img/ajax-loader.gif" />
+                        <button id="btnSave" className="btn btn-default btn-primary">{conn != null ? "Save" : "Add"}</button>
+                        <button id="btnCancel" className="btn btn-default" onClick={this.onClear}>Cancel</button>
+                    </p>
+                    <p className="bg-success">{this.state.successMessage}</p>
+                    <p className="bg-danger error-summary"></p>
+                </form>
             </div>
           </div>
         );

--- a/src/RedisReact/RedisReact/js/redis.js
+++ b/src/RedisReact/RedisReact/js/redis.js
@@ -51,9 +51,9 @@
         args.push(cmd.substring(lastPos));
         return args;
     },
-    getConnection: function () {
+    getConnections: function () {
         return $.ajax({
-            url: "/connection",
+            url: "/connections",
             dataType: "json"
         });
     },

--- a/src/RedisReact/RedisReact/js/redis.js
+++ b/src/RedisReact/RedisReact/js/redis.js
@@ -57,6 +57,24 @@
             dataType: "json"
         });
     },
+    setConnection: function(conn) {
+        return $.ajax({
+            method: "POST",
+            url: "/connections",
+            dataType: "json",
+            data: conn
+        });
+    },
+    deleteConnection: function (conn) {
+        return $.ajax({
+            method: "DELETE",
+            url: "/connections/" + conn.host + "?port=" + conn.port,
+            dataType: "json"
+        })
+        .then(function(r) {
+            return r;
+        });
+    },
     search: function (query) {
         var $this = this;
         return $.ajax({

--- a/src/RedisReact/RedisReact/js/stores.js
+++ b/src/RedisReact/RedisReact/js/stores.js
@@ -7,7 +7,7 @@ var RouteHandler = Router.RouteHandler;
 
 var Actions = Reflux.createActions([
     'viewInfo',
-    'loadConnection',
+    'loadConnections',
     'search',
     'loadKey',
     'loadRelatedKeyInfo',
@@ -108,14 +108,21 @@ var InfoStore = Reflux.createStore({
 
 var ConnectionStore = Reflux.createStore({
     init: function () {
-        this.listenTo(Actions.loadConnection, this.loadConnection);
-        this.connection = null;
+        this.listenTo(Actions.loadConnections, this.loadConnections);
+        this.connections = null;
     },
-    loadConnection: function () {
+    loadConnections: function () {
         var $this = this;
-        Redis.getConnection()
+        Redis.getConnections()
             .done(function (r) {
-                $this.trigger($this.connection = r);
+                var activeConnection = null;
+                for (let conn of r.connections) {
+                    if (conn.isActive) {
+                        activeConnection = conn;
+                    }
+                }
+                $this.connections = r.connections;
+                $this.trigger(activeConnection);
             });
     }
 });


### PR DESCRIPTION
Add the ability to store multiple connections on the server (and persist the current/active one).

The main point here is that I'd like to use this UI to manage a cluster, and I don't want to have to enter the connection details each time. 

Ideally, I'd want to be able to connect to slaves as well as master, but I couldn't get that easily working with the way the server code is currently written. I'm all ears for suggestions :)

The use case: we currently use a tool to do manual searching more on the slaves, while we do editing on the master, to try and reduce any contention on master when troubleshooting a live environment. I'd like to be able to do something similar here (assuming you find multiple connections worth merging, of course).