### PR TITLE
Extend software requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ To run on Windows, download the self-extracting Winforms App:
 
 #### [RedisReact-winforms.exe](https://github.com/ServiceStackApps/RedisReact/raw/master/dist/RedisReact-winforms.exe) (23.9MB)
 
-> Windows requires .NET 4.5 installed which is pre-installed on recent version of Windows
+> Windows requires .NET 4.5 installed which is pre-installed on recent version of Windows. Also VC 2012 Redistributable needs to be installed.
 
 ### OSX
 


### PR DESCRIPTION
I suppose it will be helpful for others if we provide more specific requirements. In case VC 2012 redistributable is not installed application just crash and doesn't show any error messages and makes it a little bit complicated to figure out what exactly goes wrong.